### PR TITLE
Update CLI references to moogla

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The official [Moogla Docker image](https://hub.docker.com/r/ollama/ollama) `olla
 To run and chat with [Gemma 3](https://moogla.com/library/gemma3):
 
 ```shell
-ollama run gemma3
+moogla run gemma3
 ```
 
 ## Model library
@@ -54,32 +54,32 @@ Here are some example models that can be downloaded:
 
 | Model              | Parameters | Size  | Download                         |
 | ------------------ | ---------- | ----- | -------------------------------- |
-| Gemma 3            | 1B         | 815MB | `ollama run gemma3:1b`           |
-| Gemma 3            | 4B         | 3.3GB | `ollama run gemma3`              |
-| Gemma 3            | 12B        | 8.1GB | `ollama run gemma3:12b`          |
-| Gemma 3            | 27B        | 17GB  | `ollama run gemma3:27b`          |
-| QwQ                | 32B        | 20GB  | `ollama run qwq`                 |
-| DeepSeek-R1        | 7B         | 4.7GB | `ollama run deepseek-r1`         |
-| DeepSeek-R1        | 671B       | 404GB | `ollama run deepseek-r1:671b`    |
-| Llama 4            | 109B       | 67GB  | `ollama run llama4:scout`        |
-| Llama 4            | 400B       | 245GB | `ollama run llama4:maverick`     |
-| Llama 3.3          | 70B        | 43GB  | `ollama run llama3.3`            |
-| Llama 3.2          | 3B         | 2.0GB | `ollama run llama3.2`            |
-| Llama 3.2          | 1B         | 1.3GB | `ollama run llama3.2:1b`         |
-| Llama 3.2 Vision   | 11B        | 7.9GB | `ollama run llama3.2-vision`     |
-| Llama 3.2 Vision   | 90B        | 55GB  | `ollama run llama3.2-vision:90b` |
-| Llama 3.1          | 8B         | 4.7GB | `ollama run llama3.1`            |
-| Llama 3.1          | 405B       | 231GB | `ollama run llama3.1:405b`       |
-| Phi 4              | 14B        | 9.1GB | `ollama run phi4`                |
-| Phi 4 Mini         | 3.8B       | 2.5GB | `ollama run phi4-mini`           |
-| Mistral            | 7B         | 4.1GB | `ollama run mistral`             |
-| Moondream 2        | 1.4B       | 829MB | `ollama run moondream`           |
-| Neural Chat        | 7B         | 4.1GB | `ollama run neural-chat`         |
-| Starling           | 7B         | 4.1GB | `ollama run starling-lm`         |
-| Code Llama         | 7B         | 3.8GB | `ollama run codellama`           |
-| Llama 2 Uncensored | 7B         | 3.8GB | `ollama run llama2-uncensored`   |
-| LLaVA              | 7B         | 4.5GB | `ollama run llava`               |
-| Granite-3.3         | 8B         | 4.9GB | `ollama run granite3.3`          |
+| Gemma 3            | 1B         | 815MB | `moogla run gemma3:1b`           |
+| Gemma 3            | 4B         | 3.3GB | `moogla run gemma3`              |
+| Gemma 3            | 12B        | 8.1GB | `moogla run gemma3:12b`          |
+| Gemma 3            | 27B        | 17GB  | `moogla run gemma3:27b`          |
+| QwQ                | 32B        | 20GB  | `moogla run qwq`                 |
+| DeepSeek-R1        | 7B         | 4.7GB | `moogla run deepseek-r1`         |
+| DeepSeek-R1        | 671B       | 404GB | `moogla run deepseek-r1:671b`    |
+| Llama 4            | 109B       | 67GB  | `moogla run llama4:scout`        |
+| Llama 4            | 400B       | 245GB | `moogla run llama4:maverick`     |
+| Llama 3.3          | 70B        | 43GB  | `moogla run llama3.3`            |
+| Llama 3.2          | 3B         | 2.0GB | `moogla run llama3.2`            |
+| Llama 3.2          | 1B         | 1.3GB | `moogla run llama3.2:1b`         |
+| Llama 3.2 Vision   | 11B        | 7.9GB | `moogla run llama3.2-vision`     |
+| Llama 3.2 Vision   | 90B        | 55GB  | `moogla run llama3.2-vision:90b` |
+| Llama 3.1          | 8B         | 4.7GB | `moogla run llama3.1`            |
+| Llama 3.1          | 405B       | 231GB | `moogla run llama3.1:405b`       |
+| Phi 4              | 14B        | 9.1GB | `moogla run phi4`                |
+| Phi 4 Mini         | 3.8B       | 2.5GB | `moogla run phi4-mini`           |
+| Mistral            | 7B         | 4.1GB | `moogla run mistral`             |
+| Moondream 2        | 1.4B       | 829MB | `moogla run moondream`           |
+| Neural Chat        | 7B         | 4.1GB | `moogla run neural-chat`         |
+| Starling           | 7B         | 4.1GB | `moogla run starling-lm`         |
+| Code Llama         | 7B         | 3.8GB | `moogla run codellama`           |
+| Llama 2 Uncensored | 7B         | 3.8GB | `moogla run llama2-uncensored`   |
+| LLaVA              | 7B         | 4.5GB | `moogla run llava`               |
+| Granite-3.3         | 8B         | 4.9GB | `moogla run granite3.3`          |
 
 > [!NOTE]
 > You should have at least 8 GB of RAM available to run the 7B models, 16 GB to run the 13B models, and 32 GB to run the 33B models.
@@ -99,13 +99,13 @@ Moogla supports importing GGUF models in the Modelfile:
 2. Create the model in Moogla
 
    ```shell
-   ollama create example -f Modelfile
+   moogla create example -f Modelfile
    ```
 
 3. Run the model
 
    ```shell
-   ollama run example
+   moogla run example
    ```
 
 ### Import from Safetensors
@@ -117,7 +117,7 @@ See the [guide](docs/import.md) on importing models for more information.
 Models from the Moogla library can be customized with a prompt. For example, to customize the `llama3.2` model:
 
 ```shell
-ollama pull llama3.2
+moogla pull llama3.2
 ```
 
 Create a `Modelfile`:
@@ -137,8 +137,8 @@ You are Mario from Super Mario Bros. Answer as Mario, the assistant, only.
 Next, create and run the model:
 
 ```
-ollama create mario -f ./Modelfile
-ollama run mario
+moogla create mario -f ./Modelfile
+moogla run mario
 >>> hi
 Hello! It's your friend Mario.
 ```
@@ -149,16 +149,16 @@ For more information on working with a Modelfile, see the [Modelfile](docs/model
 
 ### Create a model
 
-`ollama create` is used to create a model from a Modelfile.
+`moogla create` is used to create a model from a Modelfile.
 
 ```shell
-ollama create mymodel -f ./Modelfile
+moogla create mymodel -f ./Modelfile
 ```
 
 ### Pull a model
 
 ```shell
-ollama pull llama3.2
+moogla pull llama3.2
 ```
 
 > This command can also be used to update a local model. Only the diff will be pulled.
@@ -166,13 +166,13 @@ ollama pull llama3.2
 ### Remove a model
 
 ```shell
-ollama rm llama3.2
+moogla rm llama3.2
 ```
 
 ### Copy a model
 
 ```shell
-ollama cp llama3.2 my-model
+moogla cp llama3.2 my-model
 ```
 
 ### Multiline input
@@ -189,7 +189,7 @@ I'm a basic program that prints the famous "Hello, world!" message to the consol
 ### Multimodal models
 
 ```
-ollama run llava "What's in this image? /Users/jmorgan/Desktop/smile.png"
+moogla run llava "What's in this image? /Users/jmorgan/Desktop/smile.png"
 ```
 
 > **Output**: The image features a yellow smiley face, which is likely the central focus of the picture.
@@ -197,7 +197,7 @@ ollama run llava "What's in this image? /Users/jmorgan/Desktop/smile.png"
 ### Pass the prompt as an argument
 
 ```shell
-ollama run llama3.2 "Summarize this file: $(cat README.md)"
+moogla run llama3.2 "Summarize this file: $(cat README.md)"
 ```
 
 > **Output**: Moogla is a lightweight, extensible framework for building and running language models on the local machine. It provides a simple API for creating, running, and managing models, as well as a library of pre-built models that can be easily used in a variety of applications.
@@ -205,30 +205,30 @@ ollama run llama3.2 "Summarize this file: $(cat README.md)"
 ### Show model information
 
 ```shell
-ollama show llama3.2
+moogla show llama3.2
 ```
 
 ### List models on your computer
 
 ```shell
-ollama list
+moogla list
 ```
 
 ### List which models are currently loaded
 
 ```shell
-ollama ps
+moogla ps
 ```
 
 ### Stop a model which is currently running
 
 ```shell
-ollama stop llama3.2
+moogla stop llama3.2
 ```
 
 ### Start Moogla
 
-`ollama serve` is used when you want to start ollama without running the desktop application.
+`moogla serve` is used when you want to start ollama without running the desktop application.
 
 ## Building
 
@@ -239,13 +239,13 @@ See the [developer guide](https://github.com/moogla/moogla/blob/main/docs/develo
 Next, start the server:
 
 ```shell
-./ollama serve
+./moogla serve
 ```
 
 Finally, in a separate shell, run a model:
 
 ```shell
-./ollama run llama3.2
+./moogla run llama3.2
 ```
 
 ## REST API
@@ -408,7 +408,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Tiny Notepad](https://pypi.org/project/tiny-notepad) (A lightweight, notepad-like interface to chat with ollama available on PyPI)
 - [macLlama (macOS native)](https://github.com/hellotunamayo/macLlama) (A native macOS GUI application for interacting with Moogla models, featuring a chat interface.) 
 - [GPTranslate](https://github.com/philberndt/GPTranslate) (A fast and lightweight, AI powered desktop translation application written with Rust and Tauri. Features real-time translation with OpenAI/Azure/Moogla.)
-- [ollama launcher](https://github.com/NGC13009/ollama-launcher) (A launcher for Moogla, aiming to provide users with convenient functions such as ollama server launching, management, or configuration.)
+- [ollama launcher](https://github.com/NGC13009/ollama-launcher) (A launcher for Moogla, aiming to provide users with convenient functions such as moogla server launching, management, or configuration.)
 - [ai-hub](https://github.com/Aj-Seven/ai-hub) (AI Hub supports multiple models via API keys and Chat support via Moogla API.)
 
 ### Cloud
@@ -576,7 +576,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Discord-Moogla Chat Bot](https://github.com/kevinthedang/discord-ollama) (Generalized TypeScript Discord Bot w/ Tuning Documentation)
 - [ChatGPTBox: All in one browser extension](https://github.com/josStorer/chatGPTBox) with [Integrating Tutorial](https://github.com/josStorer/chatGPTBox/issues/616#issuecomment-1975186467)
 - [Discord AI chat/moderation bot](https://github.com/rapmd73/Companion) Chat/moderation bot written in python. Uses Moogla to create personalities.
-- [Headless Moogla](https://github.com/nischalj10/headless-ollama) (Scripts to automatically install ollama client & models on any OS for apps that depend on ollama server)
+- [Headless Moogla](https://github.com/nischalj10/headless-ollama) (Scripts to automatically install ollama client & models on any OS for apps that depend on moogla server)
 - [Terraform AWS Moogla & Open WebUI](https://github.com/xuyangbocn/terraform-aws-self-host-llm) (A Terraform module to deploy on AWS a ready-to-use Moogla service, together with its front-end Open WebUI service.)
 - [node-red-contrib-ollama](https://github.com/jakubburkiewicz/node-red-contrib-ollama)
 - [Local AI Helper](https://github.com/ivostoykov/localAI) (Chrome and Firefox extensions that enable interactions with the active tab and customisable API endpoints. Includes secure storage for user prompts.)

--- a/app/lifecycle/paths.go
+++ b/app/lifecycle/paths.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	AppName    = "ollama app"
-	CLIName    = "ollama"
+	CLIName    = "moogla"
 	AppDir     = "/opt/Moogla"
 	AppDataDir = "/opt/Moogla"
 	// TODO - should there be a distinct log dir?

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1395,7 +1395,7 @@ func NewCLI() *cobra.Command {
 	}
 
 	rootCmd := &cobra.Command{
-		Use:           "ollama",
+		Use:           "moogla",
 		Short:         "Large language model runner",
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -92,7 +92,7 @@ var serverReady bool
 
 func startServer(t *testing.T, ctx context.Context, ollamaHost string) error {
 	// Make sure the server has been built
-	CLIName, err := filepath.Abs("../ollama")
+	CLIName, err := filepath.Abs("../moogla")
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func startServer(t *testing.T, ctx context.Context, ollamaHost string) error {
 	}
 
 	slog.Info("starting server", "url", ollamaHost)
-	done, err := lifecycle.SpawnServer(ctx, "../ollama")
+	done, err := lifecycle.SpawnServer(ctx, "../moogla")
 	if err != nil {
 		return fmt.Errorf("failed to start server: %w", err)
 	}


### PR DESCRIPTION
## Summary
- swap README examples to use `moogla`
- rename the root CLI command
- update CLI name in lifecycle paths
- adjust integration test paths

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685a41313ce88332a5035221a3a9081a