### PR TITLE
Fix template parsing logic

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -545,9 +545,6 @@ func setTemplate(layers []Layer, t string) ([]Layer, error) {
 	if _, err := template.Parse(t); err != nil {
 		return nil, fmt.Errorf("%w: %s", errBadTemplate, err)
 	}
-	if _, err := template.Parse(t); err != nil {
-		return nil, fmt.Errorf("%w: %s", errBadTemplate, err)
-	}
 
 	blob := strings.NewReader(t)
 	layer, err := NewLayer(blob, "application/vnd.ollama.image.template")


### PR DESCRIPTION
## Summary
- remove redundant template parsing in `setTemplate`
- return an error if parsing fails

## Testing
- `go test ./...` *(fails: Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685a4c20cfc08332a2c999a202833932