### PR TITLE
Fix log file permissions

### DIFF
--- a/app/lifecycle/logging.go
+++ b/app/lifecycle/logging.go
@@ -21,7 +21,7 @@ func InitLogging() {
 		// TODO - write one-line to the app.log file saying we're running in console mode to help avoid confusion
 	} else {
 		rotateLogs(AppLogFile)
-		logFile, err = os.OpenFile(AppLogFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o755)
+		logFile, err = os.OpenFile(AppLogFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
 		if err != nil {
 			slog.Error(fmt.Sprintf("failed to create server log %v", err))
 			return

--- a/app/lifecycle/server.go
+++ b/app/lifecycle/server.go
@@ -61,7 +61,7 @@ func start(ctx context.Context, command string) (*exec.Cmd, error) {
 	}
 
 	rotateLogs(ServerLogFile)
-	logFile, err := os.OpenFile(ServerLogFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o755)
+	logFile, err := os.OpenFile(ServerLogFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create server log: %w", err)
 	}


### PR DESCRIPTION
## Summary
- ensure log files are created with 0644 permissions
- keep log directory creation at 0755

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685a4c21d0808332be4e0d4a7a6bae78