### PR TITLE
Add -mod=vendor flags

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,7 +202,7 @@ jobs:
 
       - name: go test
         if: always()
-        run: go test -count=1 -benchtime=1x ./...
+        run: go test -mod=vendor -count=1 -benchtime=1x ./...
 
       # TODO(bmizerany): replace this heavy tool with just the
       # tools/checks/binaries we want and then make them all run in parallel

--- a/scripts/build_darwin.sh
+++ b/scripts/build_darwin.sh
@@ -9,7 +9,7 @@ usage() {
 }
 
 export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long --dirty --always | sed -e "s/^v//g")}
-export GOFLAGS="'-ldflags=-w -s \"-X=github.com/moogla/moogla/version.Version=${VERSION#v}\" \"-X=github.com/moogla/moogla/server.mode=release\"'"
+export GOFLAGS="'-mod=vendor -ldflags=-w -s \"-X=github.com/moogla/moogla/version.Version=${VERSION#v}\" \"-X=github.com/moogla/moogla/server.mode=release\"'"
 export CGO_CPPFLAGS='-mmacosx-version-min=11.3'
 
 ARCHS="arm64 amd64"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,7 +1,7 @@
 # Common environment setup across build*.sh scripts
 
 export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long --dirty --always | sed -e "s/^v//g")}
-export GOFLAGS="'-ldflags=-w -s \"-X=github.com/moogla/moogla/version.Version=$VERSION\" \"-X=github.com/moogla/moogla/server.mode=release\"'"
+export GOFLAGS="'-mod=vendor -ldflags=-w -s \"-X=github.com/moogla/moogla/version.Version=$VERSION\" \"-X=github.com/moogla/moogla/server.mode=release\"'"
 # TODO - consider `docker buildx ls --format=json` to autodiscover platform capability
 PLATFORM=${PLATFORM:-"linux/arm64,linux/amd64"}
 DOCKER_ORG=${DOCKER_ORG:-"ollama"}

--- a/scripts/push_docker.sh
+++ b/scripts/push_docker.sh
@@ -3,7 +3,7 @@
 set -eu
 
 export VERSION=${VERSION:-0.0.0}
-export GOFLAGS="'-ldflags=-w -s \"-X=github.com/moogla/moogla/version.Version=$VERSION\" \"-X=github.com/moogla/moogla/server.mode=release\"'"
+export GOFLAGS="'-mod=vendor -ldflags=-w -s \"-X=github.com/moogla/moogla/version.Version=$VERSION\" \"-X=github.com/moogla/moogla/server.mode=release\"'"
 
 docker build \
     --push \


### PR DESCRIPTION
## Summary
- go test uses vendored modules in GitHub actions
- set `GOFLAGS` to include `-mod=vendor` in build scripts

## Testing
- `go test -mod=vendor ./...` *(fails: inconsistent vendoring)*
- `go vet -mod=vendor ./...` *(fails: inconsistent vendoring)*

------
https://chatgpt.com/codex/tasks/task_e_685ac96c1d7c8332a52fc27a4a0e8e95