### PR TITLE
return error from Register

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -88,13 +88,18 @@ func (m *Base) Config() config {
 
 var models = make(map[string]func(fs.Config) (Model, error))
 
+// ErrModelRegistered indicates a model with the same name has already been
+// registered.
+var ErrModelRegistered = errors.New("model: model already registered")
+
 // Register registers a model constructor for the given architecture
-func Register(name string, f func(fs.Config) (Model, error)) {
+func Register(name string, f func(fs.Config) (Model, error)) error {
 	if _, ok := models[name]; ok {
-		panic("model: model already registered")
+		return ErrModelRegistered
 	}
 
 	models[name] = f
+	return nil
 }
 
 // New initializes a new model instance with the provided configuration based on the metadata in the model file

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"reflect"
 	"slices"
 	"strings"
@@ -159,6 +160,23 @@ func TestGetTextProcessor(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	} else if tp != nil {
 		t.Error("expected nil tp")
+	}
+}
+
+func TestRegisterDuplicate(t *testing.T) {
+	old := models
+	models = make(map[string]func(fs.Config) (Model, error))
+	t.Cleanup(func() { models = old })
+
+	if err := Register("dup", func(fs.Config) (Model, error) { return nil, nil }); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err := Register("dup", func(fs.Config) (Model, error) { return nil, nil })
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrModelRegistered) {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 

--- a/model/models/gemma2/model.go
+++ b/model/models/gemma2/model.go
@@ -209,5 +209,7 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 }
 
 func init() {
-	model.Register("gemma2", New)
+	if err := model.Register("gemma2", New); err != nil {
+		panic(err)
+	}
 }

--- a/model/models/gemma3/model.go
+++ b/model/models/gemma3/model.go
@@ -148,5 +148,7 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 }
 
 func init() {
-	model.Register("gemma3", New)
+	if err := model.Register("gemma3", New); err != nil {
+		panic(err)
+	}
 }

--- a/model/models/llama/model.go
+++ b/model/models/llama/model.go
@@ -162,5 +162,7 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 }
 
 func init() {
-	model.Register("llama", New)
+	if err := model.Register("llama", New); err != nil {
+		panic(err)
+	}
 }

--- a/model/models/llama4/model.go
+++ b/model/models/llama4/model.go
@@ -182,5 +182,7 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 }
 
 func init() {
-	model.Register("llama4", New)
+	if err := model.Register("llama4", New); err != nil {
+		panic(err)
+	}
 }

--- a/model/models/mistral3/model.go
+++ b/model/models/mistral3/model.go
@@ -165,5 +165,7 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 }
 
 func init() {
-	model.Register("mistral3", New)
+	if err := model.Register("mistral3", New); err != nil {
+		panic(err)
+	}
 }

--- a/model/models/mllama/model.go
+++ b/model/models/mllama/model.go
@@ -114,5 +114,7 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 }
 
 func init() {
-	model.Register("mllama", New)
+	if err := model.Register("mllama", New); err != nil {
+		panic(err)
+	}
 }

--- a/model/models/qwen2/model.go
+++ b/model/models/qwen2/model.go
@@ -160,5 +160,7 @@ func New(c fs.Config) (model.Model, error) {
 }
 
 func init() {
-	model.Register("qwen2", New)
+	if err := model.Register("qwen2", New); err != nil {
+		panic(err)
+	}
 }

--- a/model/models/qwen25vl/model.go
+++ b/model/models/qwen25vl/model.go
@@ -146,5 +146,7 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 }
 
 func init() {
-	model.Register("qwen25vl", New)
+	if err := model.Register("qwen25vl", New); err != nil {
+		panic(err)
+	}
 }

--- a/model/models/qwen3/model.go
+++ b/model/models/qwen3/model.go
@@ -228,6 +228,10 @@ func New(c fs.Config) (model.Model, error) {
 }
 
 func init() {
-	model.Register("qwen3", New)
-	model.Register("qwen3moe", New)
+	if err := model.Register("qwen3", New); err != nil {
+		panic(err)
+	}
+	if err := model.Register("qwen3moe", New); err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
## Summary
- return error when registering model with a duplicate name
- update model init functions to handle Register errors
- add test for Register duplicate

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685ac96a79c48332bf03e4e20825f0f9