### PR TITLE
Replace Printf with slog in setMessages

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -637,7 +637,7 @@ func setMessages(layers []Layer, m []api.Message) ([]Layer, error) {
 		return layers, nil
 	}
 
-	fmt.Printf("removing old messages\n")
+	slog.Debug("removing old messages")
 	layers = removeLayer(layers, "application/vnd.ollama.image.messages")
 	var b bytes.Buffer
 	if err := json.NewEncoder(&b).Encode(m); err != nil {


### PR DESCRIPTION
## Summary
- replace leftover `fmt.Printf` call in `setMessages` with `slog.Debug`

## Testing
- `gofmt -w server/create.go`
- `go vet ./...` *(fails: unable to download modules)*
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685ad5168c8c83328914fde1f2b3ea1a