### PR TITLE
Use ticker for waiting on server

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -13,12 +13,13 @@ import (
 func waitForServer(ctx context.Context, client *api.Client) error {
 	// wait for the server to start
 	timeout := time.After(5 * time.Second)
-	tick := time.Tick(500 * time.Millisecond)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-timeout:
 			return errors.New("timed out waiting for server to start")
-		case <-tick:
+		case <-ticker.C:
 			if err := client.Heartbeat(ctx); err == nil {
 				return nil // server has started
 			}


### PR DESCRIPTION
## Summary
- use `time.NewTicker` in `waitForServer`
- stop ticker with `defer`

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685ad5184c68833286d6f2bf41e43232