### PR TITLE
Use WalkDir for manifest scan

### DIFF
--- a/server/manifest_test.go
+++ b/server/manifest_test.go
@@ -77,6 +77,12 @@ func TestManifests(t *testing.T) {
 			},
 			wantInvalidCount: 2,
 		},
+		"deep nested": {
+			ps: []string{
+				filepath.Join("host", "namespace", "model", "tag", "a", "b", "c", "d"),
+			},
+			wantInvalidCount: 1,
+		},
 		"upper tag": {
 			ps: []string{
 				filepath.Join("host", "namespace", "model", "TAG"),


### PR DESCRIPTION
## Summary
- walk manifest directory recursively using `filepath.WalkDir`
- test deep nested manifest paths

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685ad8d444c88332935113886b49ddb7