### PR TITLE
Add commit trace event in push

### DIFF
--- a/server/internal/client/moogla/registry.go
+++ b/server/internal/client/moogla/registry.go
@@ -431,8 +431,8 @@ func (r *Registry) Push(ctx context.Context, name string, p *PushParams) error {
 	res, err := r.send(ctx, "PUT", path, bytes.NewReader(m.Data))
 	if err == nil {
 		res.Body.Close()
+		t.commit(nil)
 	}
-	// TODO(bmizerany): add a "commit" trace event
 	return err
 }
 


### PR DESCRIPTION
## Summary
- emit a commit trace after a model push completes
- support commit events in the Trace helper

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685ad8d904a083329f54381cb6d6c9f0