### PR TITLE
Enable sharded blob storage

### DIFF
--- a/server/internal/cache/blob/cache_test.go
+++ b/server/internal/cache/blob/cache_test.go
@@ -83,6 +83,11 @@ func TestGetFile(t *testing.T) {
 	if !strings.HasPrefix(got, abs) {
 		t.Fatalf("got is not local to %q", c.dir)
 	}
+	hex := fmt.Sprintf("%x", d.sum)
+	shard := hex[:2]
+	if !strings.Contains(got, filepath.Join("blobs", shard)) {
+		t.Fatalf("got %q, want shard subdir %s", got, shard)
+	}
 }
 
 func TestBasic(t *testing.T) {

--- a/server/modelpath_test.go
+++ b/server/modelpath_test.go
@@ -27,13 +27,13 @@ func TestGetBlobsPath(t *testing.T) {
 		{
 			"valid with colon",
 			"sha256:456402914e838a953e0cf80caa6adbe75383d9e63584a964f504a7bbb8f7aad9",
-			filepath.Join(tempDir, "blobs", "sha256-456402914e838a953e0cf80caa6adbe75383d9e63584a964f504a7bbb8f7aad9"),
+			filepath.Join(tempDir, "blobs", "45", "sha256-456402914e838a953e0cf80caa6adbe75383d9e63584a964f504a7bbb8f7aad9"),
 			nil,
 		},
 		{
 			"valid with dash",
 			"sha256-456402914e838a953e0cf80caa6adbe75383d9e63584a964f504a7bbb8f7aad9",
-			filepath.Join(tempDir, "blobs", "sha256-456402914e838a953e0cf80caa6adbe75383d9e63584a964f504a7bbb8f7aad9"),
+			filepath.Join(tempDir, "blobs", "45", "sha256-456402914e838a953e0cf80caa6adbe75383d9e63584a964f504a7bbb8f7aad9"),
 			nil,
 		},
 		{

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -75,11 +75,17 @@ func createTestFile(t *testing.T, name string) (string, string) {
 		t.Fatal(err)
 	}
 
-	if err := createLink(f.Name(), filepath.Join(modelDir, "blobs", fmt.Sprintf("sha256-%s", strings.TrimPrefix(digest, "sha256:")))); err != nil {
+	if err := createLink(f.Name(), blobPath(filepath.Join(modelDir, "blobs"), fmt.Sprintf("sha256-%s", strings.TrimPrefix(digest, "sha256:")))); err != nil {
 		t.Fatal(err)
 	}
 
 	return f.Name(), digest
+}
+
+func blobPath(dir, digest string) string {
+	digest = strings.ReplaceAll(digest, "sha256:", "sha256-")
+	hex := strings.TrimPrefix(digest, "sha256-")
+	return filepath.Join(dir, hex[:2], digest)
 }
 
 // equalStringSlices checks if two slices of strings are equal.


### PR DESCRIPTION
## Summary
- implement sharded directories in `DiskCache` using first byte of the digest
- create parent directories when copying or importing blobs
- resolve blob path using sharded layout in `GetBlobsPath`
- update tests for new blob locations

## Testing
- `go test ./...` *(fails: Forbidden errors while fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_685ad8db6f9c833283ec400c92fb0790