### PR TITLE
Pass logger to registry creation

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1146,7 +1146,7 @@ func allowedHostsMiddleware(addr net.Addr) gin.HandlerFunc {
 	}
 }
 
-func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
+func (s *Server) GenerateRoutes(logger *slog.Logger, rc *ollama.Registry) (http.Handler, error) {
 	corsConfig := cors.DefaultConfig()
 	corsConfig.AllowWildcard = true
 	corsConfig.AllowBrowserExtensions = true
@@ -1219,7 +1219,7 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 		// wrap old with new
 		rs := &registry.Local{
 			Client:   rc,
-			Logger:   slog.Default(), // TODO(bmizerany): Take a logger, do not use slog.Default()
+			Logger:   logger,
 			Fallback: r,
 
 			Prune: PruneLayers,
@@ -1273,7 +1273,7 @@ func Serve(ln net.Listener) error {
 		}
 	}
 
-	h, err := s.GenerateRoutes(rc)
+	h, err := s.GenerateRoutes(slog.Default(), rc)
 	if err != nil {
 		return err
 	}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"unicode"
 
+	"log/slog"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/go-cmp/cmp"
 	"github.com/moogla/moogla/api"
@@ -518,7 +520,7 @@ func TestRoutes(t *testing.T) {
 	}
 
 	s := &Server{}
-	router, err := s.GenerateRoutes(rc)
+	router, err := s.GenerateRoutes(slog.New(slog.NewTextHandler(io.Discard, nil)), rc)
 	if err != nil {
 		t.Fatalf("failed to generate routes: %v", err)
 	}


### PR DESCRIPTION
## Summary
- `GenerateRoutes` now accepts a logger
- pass slog.Default() from `Serve`
- update tests with a test logger

## Testing
- `go test ./...` *(fails: missing deps due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685ad8de55d4833287c4d0703a9f628f