### PR TITLE
Implement JSON config support in sampler

### DIFF
--- a/runner/mooglarunner/runner.go
+++ b/runner/mooglarunner/runner.go
@@ -619,7 +619,7 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 		defer grammar.Free()
 	}
 
-	sampler := sample.NewSampler(sample.Config{
+	sampler := sample.NewSamplerFromConfig(sample.Config{
 		Temperature: req.Options.Temperature,
 		TopK:        req.Options.TopK,
 		TopP:        req.Options.TopP,

--- a/sample/samplers_test.go
+++ b/sample/samplers_test.go
@@ -69,6 +69,21 @@ func TestWeighted(t *testing.T) {
 	}
 }
 
+func TestNewSamplerJSON(t *testing.T) {
+	logits := []float32{-10, 3, -10, -10}
+	sampler, err := NewSampler([]byte(`{"temperature":0}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := sampler.Sample(logits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Errorf("index mismatch: want %d, got %d", 1, got)
+	}
+}
+
 func modelHelper(t testing.TB) model.BytePairEncoding {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- allow `NewSampler` to accept JSON directly
- add `NewSamplerFromConfig` for existing callers
- update sampler JSON unmarshal implementation
- adjust runner to use `NewSamplerFromConfig`
- test JSON creation via `NewSampler`

## Testing
- `go test ./...` *(fails: failed to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685ad8df79f083329af52070a7b17e2b