### PR TITLE
Add macOS/Linux paths and log dir

### DIFF
--- a/app/lifecycle/logging_windows.go
+++ b/app/lifecycle/logging_windows.go
@@ -9,8 +9,8 @@ import (
 
 func ShowLogs() {
 	cmd_path := "c:\\Windows\\system32\\cmd.exe"
-	slog.Debug(fmt.Sprintf("viewing logs with start %s", AppDataDir))
-	cmd := exec.Command(cmd_path, "/c", "start", AppDataDir)
+	slog.Debug(fmt.Sprintf("viewing logs with start %s", LogDir))
+	cmd := exec.Command(cmd_path, "/c", "start", LogDir)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: false, CreationFlags: 0x08000000}
 	err := cmd.Start()
 	if err != nil {


### PR DESCRIPTION
## Summary
- add LogDir variable for centralizing log storage
- implement macOS and Linux initialization in `paths.go`
- adjust ShowLogs on Windows to use `LogDir`

## Testing
- `go test ./...` *(fails: fetching modules requires network)*

------
https://chatgpt.com/codex/tasks/task_e_685ad8dfe6b8833289586747974ce1ce