### PR TITLE
Avoid panic in Models

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -225,7 +225,11 @@ func detectModelTypeFromFiles(files map[string]string) string {
 }
 
 func convertFromSafetensors(files map[string]string, baseLayers []*layerGGML, isAdapter bool, fn func(resp api.ProgressResponse)) ([]*layerGGML, error) {
-	tmpDir, err := os.MkdirTemp(envconfig.Models(), "goobla-safetensors")
+	modelsDir, err := envconfig.Models()
+	if err != nil {
+		return nil, err
+	}
+	tmpDir, err := os.MkdirTemp(modelsDir, "goobla-safetensors")
 	if err != nil {
 		return nil, err
 	}

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -103,7 +103,11 @@ func (mp ModelPath) GetManifestPath() (string, error) {
 	if !name.IsValid() {
 		return "", fs.ErrNotExist
 	}
-	return filepath.Join(envconfig.Models(), "manifests", name.Filepath()), nil
+	mdir, err := envconfig.Models()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(mdir, "manifests", name.Filepath()), nil
 }
 
 func (mp ModelPath) BaseURL() *url.URL {
@@ -114,7 +118,11 @@ func (mp ModelPath) BaseURL() *url.URL {
 }
 
 func GetManifestPath() (string, error) {
-	path := filepath.Join(envconfig.Models(), "manifests")
+	mdir, err := envconfig.Models()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(mdir, "manifests")
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		return "", fmt.Errorf("%w: ensure path elements are traversable", err)
 	}
@@ -132,8 +140,12 @@ func GetBlobsPath(digest string) (string, error) {
 	}
 
 	digest = strings.ReplaceAll(digest, ":", "-")
+	mdir, err := envconfig.Models()
+	if err != nil {
+		return "", err
+	}
 	if digest == "" {
-		path := filepath.Join(envconfig.Models(), "blobs")
+		path := filepath.Join(mdir, "blobs")
 		if err := os.MkdirAll(path, 0o755); err != nil {
 			return "", fmt.Errorf("%w: ensure path elements are traversable", err)
 		}
@@ -141,12 +153,12 @@ func GetBlobsPath(digest string) (string, error) {
 	}
 
 	hex := strings.TrimPrefix(digest, "sha256-")
-	path := filepath.Join(envconfig.Models(), "blobs", hex[:2], digest)
+	path := filepath.Join(mdir, "blobs", hex[:2], digest)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", fmt.Errorf("%w: ensure path elements are traversable", err)
 	}
 
-	old := filepath.Join(envconfig.Models(), "blobs", digest)
+	old := filepath.Join(mdir, "blobs", digest)
 	if _, err := os.Stat(old); err == nil {
 		return old, nil
 	}

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -28,7 +28,7 @@ func createBinFile(t *testing.T, kv map[string]any, ti []*ggml.Tensor) (string, 
 	t.Helper()
 	t.Setenv("GOOBLA_MODELS", cmp.Or(os.Getenv("GOOBLA_MODELS"), t.TempDir()))
 
-	modelDir := envconfig.Models()
+	modelDir, _ := envconfig.Models()
 
 	f, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {


### PR DESCRIPTION
## Summary
- return `(string, error)` from `envconfig.Models`
- propagate potential errors to callers in server code and tests

## Testing
- `go test ./...` *(fails: cannot download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685b076fa0a88332b8aad6249ca82920