### PR TITLE
Handle encoder cache config errors

### DIFF
--- a/kvcache/cache.go
+++ b/kvcache/cache.go
@@ -39,7 +39,7 @@ type Cache interface {
 	// an empty ml.CacheConfig.
 	//
 	// Most models will not need to use this.
-	SetConfig(ml.CacheConfig)
+	SetConfig(ml.CacheConfig) error
 
 	// ** cache management **
 

--- a/kvcache/causal.go
+++ b/kvcache/causal.go
@@ -149,12 +149,13 @@ func (c *Causal) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity
 	c.backend = backend
 }
 
-func (c *Causal) SetConfig(config ml.CacheConfig) {
+func (c *Causal) SetConfig(config ml.CacheConfig) error {
 	if c.config != nil {
-		panic("config cannot be changed after being previously set, either by the model or backend")
+		return fmt.Errorf("config cannot be changed after being previously set, either by the model or backend")
 	}
 
 	c.config = &config
+	return nil
 }
 
 func (c *Causal) Close() {

--- a/kvcache/encoder.go
+++ b/kvcache/encoder.go
@@ -55,6 +55,12 @@ func NewEncoderCache() *EncoderCache {
 }
 
 func (c *EncoderCache) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int) {
+	if err := c.SetBackend(backend, maxSequences); err != nil {
+		panic(err)
+	}
+}
+
+func (c *EncoderCache) SetBackend(backend ml.Backend, maxSequences int) error {
 	if c.config == nil {
 		var config ml.CacheConfig
 		if cc, ok := backend.(ml.BackendCacheConfig); ok {
@@ -64,22 +70,28 @@ func (c *EncoderCache) Init(backend ml.Backend, dtype ml.DType, maxSequences, ca
 	}
 
 	if maxSequences > 1 {
-		panic(fmt.Errorf("encoder cache does not support multiple sequences; requested: %v", maxSequences))
+		return fmt.Errorf("encoder cache does not support multiple sequences; requested: %v", maxSequences)
 	}
 
 	if c.config.CachePadding != 0 && c.config.CachePadding != 1 {
-		panic(fmt.Errorf("encoder cache is unable to enforce requested CachePadding (%v)", c.config.CachePadding))
+		return fmt.Errorf("encoder cache is unable to enforce requested CachePadding (%v)", c.config.CachePadding)
 	}
 
 	c.backend = backend
+	return nil
 }
 
-func (c *EncoderCache) SetConfig(config ml.CacheConfig) {
+func (c *EncoderCache) SetConfig(config ml.CacheConfig) error {
 	if c.config != nil {
-		panic("config cannot be changed after being previously set, either by the model or backend")
+		return fmt.Errorf("config cannot be changed after being previously set, either by the model or backend")
+	}
+
+	if config.CachePadding != 0 && config.CachePadding != 1 {
+		return fmt.Errorf("encoder cache is unable to enforce requested CachePadding (%v)", config.CachePadding)
 	}
 
 	c.config = &config
+	return nil
 }
 
 func (c *EncoderCache) Close() {

--- a/kvcache/wrapper.go
+++ b/kvcache/wrapper.go
@@ -29,10 +29,13 @@ func (c *WrapperCache) Init(backend ml.Backend, dtype ml.DType, maxSequences, ca
 	}
 }
 
-func (c *WrapperCache) SetConfig(config ml.CacheConfig) {
+func (c *WrapperCache) SetConfig(config ml.CacheConfig) error {
 	for _, cache := range c.caches {
-		cache.SetConfig(config)
+		if err := cache.SetConfig(config); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (c *WrapperCache) Close() {

--- a/model/models/gemma2/model.go
+++ b/model/models/gemma2/model.go
@@ -72,7 +72,9 @@ func New(c fs.Config) (model.Model, error) {
 
 	slidingWindowLen := int32(c.Uint("attention.sliding_window"))
 	m.Cache = kvcache.NewWrapperCache(kvcache.NewSWACache(slidingWindowLen, m.Shift), kvcache.NewCausalCache(m.Shift))
-	m.Cache.SetConfig(ml.CacheConfig{})
+	if err := m.Cache.SetConfig(ml.CacheConfig{}); err != nil {
+		return nil, err
+	}
 
 	return &m, nil
 }

--- a/model/models/mllama/model.go
+++ b/model/models/mllama/model.go
@@ -54,7 +54,9 @@ func New(c fs.Config) (model.Model, error) {
 	}
 
 	encoderCache := kvcache.NewEncoderCache()
-	encoderCache.SetConfig(ml.CacheConfig{})
+	if err := encoderCache.SetConfig(ml.CacheConfig{}); err != nil {
+		return nil, err
+	}
 	m.Cache = kvcache.NewWrapperCache(encoderCache, kvcache.NewCausalCache(m.TextModel.Shift))
 
 	return &m, nil

--- a/runner/gooblarunner/cache_test.go
+++ b/runner/gooblarunner/cache_test.go
@@ -445,9 +445,10 @@ func (m *mockCache) Init(backend ml.Backend, dtype ml.DType, maxSequences, capac
 func (m *mockCache) Close()                                                                        {}
 func (m *mockCache) StartForward(ctx ml.Context, batch input.Batch, reserve bool) error            { return nil }
 func (m *mockCache) CopyPrefix(srcSeq, dstSeq int, len int32)                                      {}
-func (m *mockCache) SetConfig(ml.CacheConfig)                                                      {}
-func (m *mockCache) CanResume(seq int, pos int32) bool                                             { return true }
-
+func (m *mockCache) SetConfig(ml.CacheConfig) error {
+	return nil
+}
+func (m *mockCache) CanResume(seq int, pos int32) bool { return true }
 func TestShiftCacheSlot(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary
- update `Cache` interface to allow error returns from `SetConfig`
- ensure encoder cache validates backend via `SetBackend`
- propagate config errors through wrapper and model constructors
- adjust mock cache for tests

## Testing
- `go test ./...` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b0770b8e4833296ced0969b56301f