### PR TITLE
Add typed prompt support to openai completions

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -117,7 +117,7 @@ type ChatCompletionChunk struct {
 	Usage             *Usage        `json:"usage,omitempty"`
 }
 
-// TODO (https://github.com/goobla/goobla/issues/5259): support []string, []int and [][]int
+// ref: https://github.com/goobla/goobla/issues/5259 - supports []string, []int and [][]int
 type CompletionRequest struct {
 	Model            string         `json:"model"`
 	Prompt           any            `json:"prompt"`
@@ -578,6 +578,20 @@ func fromCompleteRequest(r CompletionRequest) (api.GenerateRequest, error) {
 	switch p := r.Prompt.(type) {
 	case string:
 		prompt = p
+	case []string:
+		if len(p) > 0 {
+			var sb strings.Builder
+			for _, s := range p {
+				sb.WriteString(s)
+			}
+			prompt = sb.String()
+		}
+	case []int:
+		context = append(context, p...)
+	case [][]int:
+		if len(p) > 0 {
+			context = append(context, p[0]...)
+		}
 	case []any:
 		if len(p) == 0 {
 			prompt = ""

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -567,6 +567,73 @@ func TestCompletionsMiddleware(t *testing.T) {
 	}
 }
 
+func TestFromCompleteRequestPromptTypes(t *testing.T) {
+	testCases := []struct {
+		name   string
+		req    CompletionRequest
+		expect api.GenerateRequest
+	}{
+		{
+			name: "string slice",
+			req:  CompletionRequest{Model: "test-model", Prompt: []string{"Hello", "World"}},
+			expect: api.GenerateRequest{
+				Model:  "test-model",
+				Prompt: "HelloWorld",
+				Options: map[string]any{
+					"frequency_penalty": float32(0),
+					"presence_penalty":  float32(0),
+					"temperature":       1.0,
+					"top_p":             1.0,
+				},
+				Stream: &False,
+			},
+		},
+		{
+			name: "token slice",
+			req:  CompletionRequest{Model: "test-model", Prompt: []int{1, 2, 3}},
+			expect: api.GenerateRequest{
+				Model:   "test-model",
+				Context: []int{1, 2, 3},
+				Options: map[string]any{
+					"frequency_penalty": float32(0),
+					"presence_penalty":  float32(0),
+					"temperature":       1.0,
+					"top_p":             1.0,
+				},
+				Stream: &False,
+			},
+		},
+		{
+			name: "nested token slice",
+			req:  CompletionRequest{Model: "test-model", Prompt: [][]int{{1, 2, 3}}},
+			expect: api.GenerateRequest{
+				Model:   "test-model",
+				Context: []int{1, 2, 3},
+				Options: map[string]any{
+					"frequency_penalty": float32(0),
+					"presence_penalty":  float32(0),
+					"temperature":       1.0,
+					"top_p":             1.0,
+				},
+				Stream: &False,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := fromCompleteRequest(tc.req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expect, got); diff != "" {
+				t.Fatalf("requests did not match: %s", diff)
+			}
+		})
+	}
+}
+
 func TestEmbeddingsMiddleware(t *testing.T) {
 	type testCase struct {
 		name string


### PR DESCRIPTION
## Summary
- allow slice prompts in `fromCompleteRequest`
- document issue resolution
- test typed prompt handling

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b0d699a84833298c9ad9e69340e8e