### PR TITLE
Refactor openai to subpackages

### DIFF
--- a/openai/doc.go
+++ b/openai/doc.go
@@ -1,0 +1,3 @@
+package openai
+
+// Package openai provides compatibility layers for the OpenAI REST API.

--- a/openai/middleware/middleware.go
+++ b/openai/middleware/middleware.go
@@ -1,0 +1,130 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/goobla/goobla/api"
+	opentypes "github.com/goobla/goobla/openai/types"
+	"github.com/goobla/goobla/openai/writer"
+)
+
+func ListMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		w := &writer.ListWriter{BaseWriter: writer.BaseWriter{ResponseWriter: c.Writer}}
+		c.Writer = w
+		c.Next()
+	}
+}
+
+func RetrieveMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var b bytes.Buffer
+		if err := json.NewEncoder(&b).Encode(api.ShowRequest{Name: c.Param("model")}); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, opentypes.NewError(http.StatusInternalServerError, err.Error()))
+			return
+		}
+		c.Request.Body = io.NopCloser(&b)
+		w := &writer.RetrieveWriter{BaseWriter: writer.BaseWriter{ResponseWriter: c.Writer}, Model: c.Param("model")}
+		c.Writer = w
+		c.Next()
+	}
+}
+
+func CompletionsMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req opentypes.CompletionRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, opentypes.NewError(http.StatusBadRequest, err.Error()))
+			return
+		}
+		var b bytes.Buffer
+		genReq, err := opentypes.FromCompleteRequest(req)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, opentypes.NewError(http.StatusBadRequest, err.Error()))
+			return
+		}
+		if err := json.NewEncoder(&b).Encode(genReq); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, opentypes.NewError(http.StatusInternalServerError, err.Error()))
+			return
+		}
+		c.Request.Body = io.NopCloser(&b)
+		w := &writer.CompleteWriter{
+			BaseWriter:    writer.BaseWriter{ResponseWriter: c.Writer},
+			Stream:        req.Stream,
+			ID:            fmt.Sprintf("cmpl-%d", rand.Intn(999)),
+			StreamOptions: req.StreamOptions,
+		}
+		c.Writer = w
+		c.Next()
+	}
+}
+
+func EmbeddingsMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req opentypes.EmbedRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, opentypes.NewError(http.StatusBadRequest, err.Error()))
+			return
+		}
+		if req.Input == "" {
+			req.Input = []string{""}
+		}
+		if req.Input == nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, opentypes.NewError(http.StatusBadRequest, "invalid input"))
+			return
+		}
+		if v, ok := req.Input.([]any); ok && len(v) == 0 {
+			c.AbortWithStatusJSON(http.StatusBadRequest, opentypes.NewError(http.StatusBadRequest, "invalid input"))
+			return
+		}
+		var b bytes.Buffer
+		if err := json.NewEncoder(&b).Encode(api.EmbedRequest{Model: req.Model, Input: req.Input}); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, opentypes.NewError(http.StatusInternalServerError, err.Error()))
+			return
+		}
+		c.Request.Body = io.NopCloser(&b)
+		w := &writer.EmbedWriter{BaseWriter: writer.BaseWriter{ResponseWriter: c.Writer}, Model: req.Model}
+		c.Writer = w
+		c.Next()
+	}
+}
+
+func ChatMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req opentypes.ChatCompletionRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, opentypes.NewError(http.StatusBadRequest, err.Error()))
+			return
+		}
+		if len(req.Messages) == 0 {
+			c.AbortWithStatusJSON(http.StatusBadRequest, opentypes.NewError(http.StatusBadRequest, "[] is too short - 'messages'"))
+			return
+		}
+		var b bytes.Buffer
+		chatReq, err := opentypes.FromChatRequest(req)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, opentypes.NewError(http.StatusBadRequest, err.Error()))
+			return
+		}
+		if err := json.NewEncoder(&b).Encode(chatReq); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, opentypes.NewError(http.StatusInternalServerError, err.Error()))
+			return
+		}
+		c.Request.Body = io.NopCloser(&b)
+		w := &writer.ChatWriter{
+			BaseWriter:    writer.BaseWriter{ResponseWriter: c.Writer},
+			Stream:        req.Stream,
+			ID:            fmt.Sprintf("chatcmpl-%d", rand.Intn(999)),
+			StreamOptions: req.StreamOptions,
+		}
+		c.Writer = w
+		c.Next()
+	}
+}

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/goobla/goobla/api"
+	mid "github.com/goobla/goobla/openai/middleware"
+	typ "github.com/goobla/goobla/openai/types"
 )
 
 const (
@@ -45,7 +47,7 @@ func TestChatMiddleware(t *testing.T) {
 		name string
 		body string
 		req  api.ChatRequest
-		err  ErrorResponse
+		err  typ.ErrorResponse
 	}
 
 	var capturedRequest *api.ChatRequest
@@ -327,7 +329,7 @@ func TestChatMiddleware(t *testing.T) {
 					{"role": "user", "content": 2}
 				]
 			}`,
-			err: ErrorResponse{
+			err: typ.ErrorResponse{
 				Error: Error{
 					Message: "invalid message content type: float64",
 					Type:    "invalid_request_error",
@@ -342,7 +344,7 @@ func TestChatMiddleware(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	router.Use(ChatMiddleware(), captureRequestMiddleware(&capturedRequest))
+	router.Use(mid.ChatMiddleware(), captureRequestMiddleware(&capturedRequest))
 	router.Handle(http.MethodPost, "/api/chat", endpoint)
 
 	for _, tc := range testCases {
@@ -355,7 +357,7 @@ func TestChatMiddleware(t *testing.T) {
 			resp := httptest.NewRecorder()
 			router.ServeHTTP(resp, req)
 
-			var errResp ErrorResponse
+			var errResp typ.ErrorResponse
 			if resp.Code != http.StatusOK {
 				if err := json.Unmarshal(resp.Body.Bytes(), &errResp); err != nil {
 					t.Fatal(err)
@@ -377,7 +379,7 @@ func TestCompletionsMiddleware(t *testing.T) {
 		name string
 		body string
 		req  api.GenerateRequest
-		err  ErrorResponse
+		err  typ.ErrorResponse
 	}
 
 	var capturedRequest *api.GenerateRequest
@@ -521,7 +523,7 @@ func TestCompletionsMiddleware(t *testing.T) {
 				"stop": [1, 2],
 				"suffix": "suffix"
 			}`,
-			err: ErrorResponse{
+			err: typ.ErrorResponse{
 				Error: Error{
 					Message: "invalid type for 'stop' field: float64",
 					Type:    "invalid_request_error",
@@ -536,7 +538,7 @@ func TestCompletionsMiddleware(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	router.Use(CompletionsMiddleware(), captureRequestMiddleware(&capturedRequest))
+	router.Use(mid.CompletionsMiddleware(), captureRequestMiddleware(&capturedRequest))
 	router.Handle(http.MethodPost, "/api/generate", endpoint)
 
 	for _, tc := range testCases {
@@ -547,7 +549,7 @@ func TestCompletionsMiddleware(t *testing.T) {
 			resp := httptest.NewRecorder()
 			router.ServeHTTP(resp, req)
 
-			var errResp ErrorResponse
+			var errResp typ.ErrorResponse
 			if resp.Code != http.StatusOK {
 				if err := json.Unmarshal(resp.Body.Bytes(), &errResp); err != nil {
 					t.Fatal(err)
@@ -572,7 +574,7 @@ func TestEmbeddingsMiddleware(t *testing.T) {
 		name string
 		body string
 		req  api.EmbedRequest
-		err  ErrorResponse
+		err  typ.ErrorResponse
 	}
 
 	var capturedRequest *api.EmbedRequest
@@ -605,7 +607,7 @@ func TestEmbeddingsMiddleware(t *testing.T) {
 			body: `{
 				"model": "test-model"
 			}`,
-			err: ErrorResponse{
+			err: typ.ErrorResponse{
 				Error: Error{
 					Message: "invalid input",
 					Type:    "invalid_request_error",
@@ -620,7 +622,7 @@ func TestEmbeddingsMiddleware(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	router.Use(EmbeddingsMiddleware(), captureRequestMiddleware(&capturedRequest))
+	router.Use(mid.EmbeddingsMiddleware(), captureRequestMiddleware(&capturedRequest))
 	router.Handle(http.MethodPost, "/api/embed", endpoint)
 
 	for _, tc := range testCases {
@@ -631,7 +633,7 @@ func TestEmbeddingsMiddleware(t *testing.T) {
 			resp := httptest.NewRecorder()
 			router.ServeHTTP(resp, req)
 
-			var errResp ErrorResponse
+			var errResp typ.ErrorResponse
 			if resp.Code != http.StatusOK {
 				if err := json.Unmarshal(resp.Body.Bytes(), &errResp); err != nil {
 					t.Fatal(err)
@@ -699,7 +701,7 @@ func TestListMiddleware(t *testing.T) {
 
 	for _, tc := range testCases {
 		router := gin.New()
-		router.Use(ListMiddleware())
+		router.Use(mid.ListMiddleware())
 		router.Handle(http.MethodGet, "/api/tags", tc.endpoint)
 		req, _ := http.NewRequest(http.MethodGet, "/api/tags", nil)
 
@@ -765,7 +767,7 @@ func TestRetrieveMiddleware(t *testing.T) {
 
 	for _, tc := range testCases {
 		router := gin.New()
-		router.Use(RetrieveMiddleware())
+		router.Use(mid.RetrieveMiddleware())
 		router.Handle(http.MethodGet, "/api/show/:model", tc.endpoint)
 		req, _ := http.NewRequest(http.MethodGet, "/api/show/test-model", nil)
 

--- a/openai/types/types.go
+++ b/openai/types/types.go
@@ -1,0 +1,587 @@
+package types
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/goobla/goobla/api"
+	"github.com/goobla/goobla/types/model"
+)
+
+var FinishReasonToolCalls = "tool_calls"
+
+type Error struct {
+	Message string  `json:"message"`
+	Type    string  `json:"type"`
+	Param   any     `json:"param"`
+	Code    *string `json:"code"`
+}
+
+type ErrorResponse struct {
+	Error Error `json:"error"`
+}
+
+type Message struct {
+	Role      string     `json:"role"`
+	Content   any        `json:"content"`
+	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
+}
+
+type Choice struct {
+	Index        int     `json:"index"`
+	Message      Message `json:"message"`
+	FinishReason *string `json:"finish_reason"`
+}
+
+type ChunkChoice struct {
+	Index        int     `json:"index"`
+	Delta        Message `json:"delta"`
+	FinishReason *string `json:"finish_reason"`
+}
+
+type CompleteChunkChoice struct {
+	Text         string  `json:"text"`
+	Index        int     `json:"index"`
+	FinishReason *string `json:"finish_reason"`
+}
+
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type ResponseFormat struct {
+	Type       string      `json:"type"`
+	JsonSchema *JsonSchema `json:"json_schema,omitempty"`
+}
+
+type JsonSchema struct {
+	Schema json.RawMessage `json:"schema"`
+}
+
+type EmbedRequest struct {
+	Input any    `json:"input"`
+	Model string `json:"model"`
+}
+
+type StreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+type ChatCompletionRequest struct {
+	Model            string          `json:"model"`
+	Messages         []Message       `json:"messages"`
+	Stream           bool            `json:"stream"`
+	StreamOptions    *StreamOptions  `json:"stream_options"`
+	MaxTokens        *int            `json:"max_tokens"`
+	Seed             *int            `json:"seed"`
+	Stop             any             `json:"stop"`
+	Temperature      *float64        `json:"temperature"`
+	FrequencyPenalty *float64        `json:"frequency_penalty"`
+	PresencePenalty  *float64        `json:"presence_penalty"`
+	TopP             *float64        `json:"top_p"`
+	ResponseFormat   *ResponseFormat `json:"response_format"`
+	Tools            []api.Tool      `json:"tools"`
+}
+
+type ChatCompletion struct {
+	Id                string   `json:"id"`
+	Object            string   `json:"object"`
+	Created           int64    `json:"created"`
+	Model             string   `json:"model"`
+	SystemFingerprint string   `json:"system_fingerprint"`
+	Choices           []Choice `json:"choices"`
+	Usage             Usage    `json:"usage,omitempty"`
+}
+
+type ChatCompletionChunk struct {
+	Id                string        `json:"id"`
+	Object            string        `json:"object"`
+	Created           int64         `json:"created"`
+	Model             string        `json:"model"`
+	SystemFingerprint string        `json:"system_fingerprint"`
+	Choices           []ChunkChoice `json:"choices"`
+	Usage             *Usage        `json:"usage,omitempty"`
+}
+
+// TODO (https://github.com/goobla/goobla/issues/5259): support []string, []int and [][]int
+
+type CompletionRequest struct {
+	Model            string         `json:"model"`
+	Prompt           any            `json:"prompt"`
+	FrequencyPenalty float32        `json:"frequency_penalty"`
+	MaxTokens        *int           `json:"max_tokens"`
+	PresencePenalty  float32        `json:"presence_penalty"`
+	Seed             *int           `json:"seed"`
+	Stop             any            `json:"stop"`
+	Stream           bool           `json:"stream"`
+	StreamOptions    *StreamOptions `json:"stream_options"`
+	Temperature      *float32       `json:"temperature"`
+	TopP             float32        `json:"top_p"`
+	Suffix           string         `json:"suffix"`
+}
+
+type Completion struct {
+	Id                string                `json:"id"`
+	Object            string                `json:"object"`
+	Created           int64                 `json:"created"`
+	Model             string                `json:"model"`
+	SystemFingerprint string                `json:"system_fingerprint"`
+	Choices           []CompleteChunkChoice `json:"choices"`
+	Usage             Usage                 `json:"usage,omitempty"`
+}
+
+type CompletionChunk struct {
+	Id                string                `json:"id"`
+	Object            string                `json:"object"`
+	Created           int64                 `json:"created"`
+	Choices           []CompleteChunkChoice `json:"choices"`
+	Model             string                `json:"model"`
+	SystemFingerprint string                `json:"system_fingerprint"`
+	Usage             *Usage                `json:"usage,omitempty"`
+}
+
+type ToolCall struct {
+	ID       string `json:"id"`
+	Index    int    `json:"index"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type Model struct {
+	Id      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
+}
+
+type Embedding struct {
+	Object    string    `json:"object"`
+	Embedding []float32 `json:"embedding"`
+	Index     int       `json:"index"`
+}
+
+type ListCompletion struct {
+	Object string  `json:"object"`
+	Data   []Model `json:"data"`
+}
+
+type EmbeddingList struct {
+	Object string         `json:"object"`
+	Data   []Embedding    `json:"data"`
+	Model  string         `json:"model"`
+	Usage  EmbeddingUsage `json:"usage,omitempty"`
+}
+
+type EmbeddingUsage struct {
+	PromptTokens int `json:"prompt_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}
+
+func NewError(code int, message string) ErrorResponse {
+	var etype string
+	switch code {
+	case http.StatusBadRequest:
+		etype = "invalid_request_error"
+	case http.StatusNotFound:
+		etype = "not_found_error"
+	default:
+		etype = "api_error"
+	}
+	return ErrorResponse{Error{Type: etype, Message: message}}
+}
+
+func ToUsage(r api.ChatResponse) Usage {
+	return Usage{
+		PromptTokens:     r.PromptEvalCount,
+		CompletionTokens: r.EvalCount,
+		TotalTokens:      r.PromptEvalCount + r.EvalCount,
+	}
+}
+
+func toolCallID() string {
+	const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 8)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return "call_" + strings.ToLower(string(b))
+}
+
+func toToolCalls(tc []api.ToolCall) []ToolCall {
+	toolCalls := make([]ToolCall, len(tc))
+	for i, tc := range tc {
+		toolCalls[i].ID = toolCallID()
+		toolCalls[i].Type = "function"
+		toolCalls[i].Function.Name = tc.Function.Name
+		toolCalls[i].Index = tc.Function.Index
+		args, err := json.Marshal(tc.Function.Arguments)
+		if err != nil {
+			slog.Error("could not marshall function arguments to json", "error", err)
+			continue
+		}
+		toolCalls[i].Function.Arguments = string(args)
+	}
+	return toolCalls
+}
+
+func ToChatCompletion(id string, r api.ChatResponse) ChatCompletion {
+	toolCalls := toToolCalls(r.Message.ToolCalls)
+	return ChatCompletion{
+		Id:                id,
+		Object:            "chat.completion",
+		Created:           r.CreatedAt.Unix(),
+		Model:             r.Model,
+		SystemFingerprint: "fp_goobla",
+		Choices: []Choice{{
+			Index:   0,
+			Message: Message{Role: r.Message.Role, Content: r.Message.Content, ToolCalls: toolCalls},
+			FinishReason: func(reason string) *string {
+				if len(toolCalls) > 0 {
+					reason = "tool_calls"
+				}
+				if len(reason) > 0 {
+					return &reason
+				}
+				return nil
+			}(r.DoneReason),
+		}},
+		Usage: ToUsage(r),
+	}
+}
+
+func ToChunk(id string, r api.ChatResponse, toolCallSent bool) ChatCompletionChunk {
+	toolCalls := toToolCalls(r.Message.ToolCalls)
+	return ChatCompletionChunk{
+		Id:                id,
+		Object:            "chat.completion.chunk",
+		Created:           time.Now().Unix(),
+		Model:             r.Model,
+		SystemFingerprint: "fp_goobla",
+		Choices: []ChunkChoice{{
+			Index: 0,
+			Delta: Message{Role: "assistant", Content: r.Message.Content, ToolCalls: toolCalls},
+			FinishReason: func(reason string) *string {
+				if len(reason) > 0 {
+					if toolCallSent {
+						return &FinishReasonToolCalls
+					}
+					return &reason
+				}
+				return nil
+			}(r.DoneReason),
+		}},
+	}
+}
+
+func ToUsageGenerate(r api.GenerateResponse) Usage {
+	return Usage{
+		PromptTokens:     r.PromptEvalCount,
+		CompletionTokens: r.EvalCount,
+		TotalTokens:      r.PromptEvalCount + r.EvalCount,
+	}
+}
+
+func ToCompletion(id string, r api.GenerateResponse) Completion {
+	return Completion{
+		Id:                id,
+		Object:            "text_completion",
+		Created:           r.CreatedAt.Unix(),
+		Model:             r.Model,
+		SystemFingerprint: "fp_goobla",
+		Choices: []CompleteChunkChoice{{
+			Text:  r.Response,
+			Index: 0,
+			FinishReason: func(reason string) *string {
+				if len(reason) > 0 {
+					return &reason
+				}
+				return nil
+			}(r.DoneReason),
+		}},
+		Usage: ToUsageGenerate(r),
+	}
+}
+
+func ToCompleteChunk(id string, r api.GenerateResponse) CompletionChunk {
+	return CompletionChunk{
+		Id:                id,
+		Object:            "text_completion",
+		Created:           time.Now().Unix(),
+		Model:             r.Model,
+		SystemFingerprint: "fp_goobla",
+		Choices: []CompleteChunkChoice{{
+			Text:  r.Response,
+			Index: 0,
+			FinishReason: func(reason string) *string {
+				if len(reason) > 0 {
+					return &reason
+				}
+				return nil
+			}(r.DoneReason),
+		}},
+	}
+}
+
+func ToListCompletion(r api.ListResponse) ListCompletion {
+	var data []Model
+	for _, m := range r.Models {
+		data = append(data, Model{
+			Id:      m.Name,
+			Object:  "model",
+			Created: m.ModifiedAt.Unix(),
+			OwnedBy: model.ParseName(m.Name).Namespace,
+		})
+	}
+	return ListCompletion{Object: "list", Data: data}
+}
+
+func ToEmbeddingList(model string, r api.EmbedResponse) EmbeddingList {
+	if r.Embeddings != nil {
+		var data []Embedding
+		for i, e := range r.Embeddings {
+			data = append(data, Embedding{Object: "embedding", Embedding: e, Index: i})
+		}
+		return EmbeddingList{
+			Object: "list",
+			Data:   data,
+			Model:  model,
+			Usage: EmbeddingUsage{
+				PromptTokens: r.PromptEvalCount,
+				TotalTokens:  r.PromptEvalCount,
+			},
+		}
+	}
+	return EmbeddingList{}
+}
+
+func ToModel(r api.ShowResponse, m string) Model {
+	return Model{
+		Id:      m,
+		Object:  "model",
+		Created: r.ModifiedAt.Unix(),
+		OwnedBy: model.ParseName(m).Namespace,
+	}
+}
+
+func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
+	var messages []api.Message
+	for _, msg := range r.Messages {
+		switch content := msg.Content.(type) {
+		case string:
+			messages = append(messages, api.Message{Role: msg.Role, Content: content})
+		case []any:
+			for _, c := range content {
+				data, ok := c.(map[string]any)
+				if !ok {
+					return nil, errors.New("invalid message format")
+				}
+				switch data["type"] {
+				case "text":
+					text, ok := data["text"].(string)
+					if !ok {
+						return nil, errors.New("invalid message format")
+					}
+					messages = append(messages, api.Message{Role: msg.Role, Content: text})
+				case "image_url":
+					var url string
+					if urlMap, ok := data["image_url"].(map[string]any); ok {
+						if url, ok = urlMap["url"].(string); !ok {
+							return nil, errors.New("invalid message format")
+						}
+					} else {
+						if url, ok = data["image_url"].(string); !ok {
+							return nil, errors.New("invalid message format")
+						}
+					}
+					types := []string{"jpeg", "jpg", "png"}
+					valid := false
+					for _, t := range types {
+						prefix := "data:image/" + t + ";base64,"
+						if strings.HasPrefix(url, prefix) {
+							url = strings.TrimPrefix(url, prefix)
+							valid = true
+							break
+						}
+					}
+					if !valid {
+						return nil, errors.New("invalid image input")
+					}
+					img, err := base64.StdEncoding.DecodeString(url)
+					if err != nil {
+						return nil, errors.New("invalid message format")
+					}
+					messages = append(messages, api.Message{Role: msg.Role, Images: []api.ImageData{img}})
+				default:
+					return nil, errors.New("invalid message format")
+				}
+			}
+		default:
+			if msg.ToolCalls == nil {
+				return nil, fmt.Errorf("invalid message content type: %T", content)
+			}
+			toolCalls := make([]api.ToolCall, len(msg.ToolCalls))
+			for i, tc := range msg.ToolCalls {
+				toolCalls[i].Function.Name = tc.Function.Name
+				err := json.Unmarshal([]byte(tc.Function.Arguments), &toolCalls[i].Function.Arguments)
+				if err != nil {
+					return nil, errors.New("invalid tool call arguments")
+				}
+			}
+			messages = append(messages, api.Message{Role: msg.Role, ToolCalls: toolCalls})
+		}
+	}
+	options := make(map[string]any)
+	switch stop := r.Stop.(type) {
+	case string:
+		options["stop"] = []string{stop}
+	case []any:
+		var stops []string
+		for _, s := range stop {
+			if str, ok := s.(string); ok {
+				stops = append(stops, str)
+			}
+		}
+		options["stop"] = stops
+	}
+	if r.MaxTokens != nil {
+		options["num_predict"] = *r.MaxTokens
+	}
+	if r.Temperature != nil {
+		options["temperature"] = *r.Temperature
+	} else {
+		options["temperature"] = 1.0
+	}
+	if r.Seed != nil {
+		options["seed"] = *r.Seed
+	}
+	if r.FrequencyPenalty != nil {
+		options["frequency_penalty"] = *r.FrequencyPenalty
+	}
+	if r.PresencePenalty != nil {
+		options["presence_penalty"] = *r.PresencePenalty
+	}
+	if r.TopP != nil {
+		options["top_p"] = *r.TopP
+	} else {
+		options["top_p"] = 1.0
+	}
+	var format json.RawMessage
+	if r.ResponseFormat != nil {
+		switch strings.ToLower(strings.TrimSpace(r.ResponseFormat.Type)) {
+		case "json_object":
+			format = json.RawMessage(`"json"`)
+		case "json_schema":
+			if r.ResponseFormat.JsonSchema != nil {
+				format = r.ResponseFormat.JsonSchema.Schema
+			}
+		}
+	}
+	return &api.ChatRequest{
+		Model:    r.Model,
+		Messages: messages,
+		Format:   format,
+		Options:  options,
+		Stream:   &r.Stream,
+		Tools:    r.Tools,
+	}, nil
+}
+
+func FromCompleteRequest(r CompletionRequest) (api.GenerateRequest, error) {
+	options := make(map[string]any)
+	switch stop := r.Stop.(type) {
+	case string:
+		options["stop"] = []string{stop}
+	case []any:
+		var stops []string
+		for _, s := range stop {
+			if str, ok := s.(string); ok {
+				stops = append(stops, str)
+			} else {
+				return api.GenerateRequest{}, fmt.Errorf("invalid type for 'stop' field: %T", s)
+			}
+		}
+		options["stop"] = stops
+	}
+	if r.MaxTokens != nil {
+		options["num_predict"] = *r.MaxTokens
+	}
+	if r.Temperature != nil {
+		options["temperature"] = *r.Temperature
+	} else {
+		options["temperature"] = 1.0
+	}
+	if r.Seed != nil {
+		options["seed"] = *r.Seed
+	}
+	options["frequency_penalty"] = r.FrequencyPenalty
+	options["presence_penalty"] = r.PresencePenalty
+	if r.TopP != 0.0 {
+		options["top_p"] = r.TopP
+	} else {
+		options["top_p"] = 1.0
+	}
+	var prompt string
+	var context []int
+	switch p := r.Prompt.(type) {
+	case string:
+		prompt = p
+	case []any:
+		if len(p) == 0 {
+			prompt = ""
+		} else {
+			switch first := p[0].(type) {
+			case string:
+				var sb strings.Builder
+				for _, v := range p {
+					s, ok := v.(string)
+					if !ok {
+						return api.GenerateRequest{}, fmt.Errorf("invalid type for 'prompt' field: %T", v)
+					}
+					sb.WriteString(s)
+				}
+				prompt = sb.String()
+			case float64:
+				for _, v := range p {
+					num, ok := v.(float64)
+					if !ok {
+						return api.GenerateRequest{}, fmt.Errorf("invalid type for 'prompt' field: %T", v)
+					}
+					context = append(context, int(num))
+				}
+			case []any:
+				var tokens []any = first
+				for _, v := range tokens {
+					num, ok := v.(float64)
+					if !ok {
+						return api.GenerateRequest{}, fmt.Errorf("invalid type for 'prompt' field: %T", v)
+					}
+					context = append(context, int(num))
+				}
+			default:
+				return api.GenerateRequest{}, fmt.Errorf("invalid type for 'prompt' field: %T", first)
+			}
+		}
+	default:
+		return api.GenerateRequest{}, fmt.Errorf("invalid type for 'prompt' field: %T", r.Prompt)
+	}
+	return api.GenerateRequest{
+		Model:   r.Model,
+		Prompt:  prompt,
+		Context: context,
+		Options: options,
+		Stream:  &r.Stream,
+		Suffix:  r.Suffix,
+	}, nil
+}

--- a/openai/writer/writer.go
+++ b/openai/writer/writer.go
@@ -1,0 +1,216 @@
+package writer
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/goobla/goobla/api"
+	opentypes "github.com/goobla/goobla/openai/types"
+)
+
+type BaseWriter struct {
+	gin.ResponseWriter
+}
+
+type ChatWriter struct {
+	Stream        bool
+	StreamOptions *opentypes.StreamOptions
+	ID            string
+	ToolCallSent  bool
+	BaseWriter
+}
+
+type CompleteWriter struct {
+	Stream        bool
+	StreamOptions *opentypes.StreamOptions
+	ID            string
+	BaseWriter
+}
+
+type ListWriter struct {
+	BaseWriter
+}
+
+type RetrieveWriter struct {
+	BaseWriter
+	Model string
+}
+
+type EmbedWriter struct {
+	BaseWriter
+	Model string
+}
+
+func (w *BaseWriter) writeError(data []byte) (int, error) {
+	var serr api.StatusError
+	if err := json.Unmarshal(data, &serr); err != nil {
+		return 0, err
+	}
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w.ResponseWriter).Encode(opentypes.NewError(http.StatusInternalServerError, serr.Error())); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (w *ChatWriter) writeResponse(data []byte) (int, error) {
+	var r api.ChatResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return 0, err
+	}
+	if w.Stream {
+		c := opentypes.ToChunk(w.ID, r, w.ToolCallSent)
+		d, err := json.Marshal(c)
+		if err != nil {
+			return 0, err
+		}
+		if !w.ToolCallSent && len(c.Choices) > 0 && len(c.Choices[0].Delta.ToolCalls) > 0 {
+			w.ToolCallSent = true
+		}
+		w.ResponseWriter.Header().Set("Content-Type", "text/event-stream")
+		if _, err = w.ResponseWriter.Write([]byte(fmt.Sprintf("data: %s\n\n", d))); err != nil {
+			return 0, err
+		}
+		if r.Done {
+			if w.StreamOptions != nil && w.StreamOptions.IncludeUsage {
+				u := opentypes.ToUsage(r)
+				c.Usage = &u
+				c.Choices = []opentypes.ChunkChoice{}
+				d, err := json.Marshal(c)
+				if err != nil {
+					return 0, err
+				}
+				if _, err = w.ResponseWriter.Write([]byte(fmt.Sprintf("data: %s\n\n", d))); err != nil {
+					return 0, err
+				}
+			}
+			if _, err = w.ResponseWriter.Write([]byte("data: [DONE]\n\n")); err != nil {
+				return 0, err
+			}
+		}
+		return len(data), nil
+	}
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w.ResponseWriter).Encode(opentypes.ToChatCompletion(w.ID, r)); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (w *ChatWriter) Write(data []byte) (int, error) {
+	if w.ResponseWriter.Status() != http.StatusOK {
+		return w.writeError(data)
+	}
+	return w.writeResponse(data)
+}
+
+func (w *CompleteWriter) writeResponse(data []byte) (int, error) {
+	var r api.GenerateResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return 0, err
+	}
+	if w.Stream {
+		c := opentypes.ToCompleteChunk(w.ID, r)
+		if w.StreamOptions != nil && w.StreamOptions.IncludeUsage {
+			c.Usage = &opentypes.Usage{}
+		}
+		d, err := json.Marshal(c)
+		if err != nil {
+			return 0, err
+		}
+		w.ResponseWriter.Header().Set("Content-Type", "text/event-stream")
+		if _, err = w.ResponseWriter.Write([]byte(fmt.Sprintf("data: %s\n\n", d))); err != nil {
+			return 0, err
+		}
+		if r.Done {
+			if w.StreamOptions != nil && w.StreamOptions.IncludeUsage {
+				u := opentypes.ToUsageGenerate(r)
+				c.Usage = &u
+				c.Choices = []opentypes.CompleteChunkChoice{}
+				d, err := json.Marshal(c)
+				if err != nil {
+					return 0, err
+				}
+				if _, err = w.ResponseWriter.Write([]byte(fmt.Sprintf("data: %s\n\n", d))); err != nil {
+					return 0, err
+				}
+			}
+			if _, err = w.ResponseWriter.Write([]byte("data: [DONE]\n\n")); err != nil {
+				return 0, err
+			}
+		}
+		return len(data), nil
+	}
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w.ResponseWriter).Encode(opentypes.ToCompletion(w.ID, r)); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (w *CompleteWriter) Write(data []byte) (int, error) {
+	if w.ResponseWriter.Status() != http.StatusOK {
+		return w.writeError(data)
+	}
+	return w.writeResponse(data)
+}
+
+func (w *ListWriter) writeResponse(data []byte) (int, error) {
+	var r api.ListResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return 0, err
+	}
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w.ResponseWriter).Encode(opentypes.ToListCompletion(r)); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (w *ListWriter) Write(data []byte) (int, error) {
+	if w.ResponseWriter.Status() != http.StatusOK {
+		return w.writeError(data)
+	}
+	return w.writeResponse(data)
+}
+
+func (w *RetrieveWriter) writeResponse(data []byte) (int, error) {
+	var r api.ShowResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return 0, err
+	}
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w.ResponseWriter).Encode(opentypes.ToModel(r, w.Model)); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (w *RetrieveWriter) Write(data []byte) (int, error) {
+	if w.ResponseWriter.Status() != http.StatusOK {
+		return w.writeError(data)
+	}
+	return w.writeResponse(data)
+}
+
+func (w *EmbedWriter) writeResponse(data []byte) (int, error) {
+	var r api.EmbedResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return 0, err
+	}
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w.ResponseWriter).Encode(opentypes.ToEmbeddingList(w.Model, r)); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (w *EmbedWriter) Write(data []byte) (int, error) {
+	if w.ResponseWriter.Status() != http.StatusOK {
+		return w.writeError(data)
+	}
+	return w.writeResponse(data)
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -33,7 +33,7 @@ import (
 	"github.com/goobla/goobla/fs/ggml"
 	"github.com/goobla/goobla/llm"
 	"github.com/goobla/goobla/logutil"
-	"github.com/goobla/goobla/openai"
+	openaimid "github.com/goobla/goobla/openai/middleware"
 	"github.com/goobla/goobla/server/internal/client/goobla"
 	"github.com/goobla/goobla/server/internal/registry"
 	"github.com/goobla/goobla/template"
@@ -1211,11 +1211,11 @@ func (s *Server) GenerateRoutes(logger *slog.Logger, rc *goobla.Registry) (http.
 	r.POST("/api/embeddings", s.EmbeddingsHandler)
 
 	// Inference (OpenAI compatibility)
-	r.POST("/v1/chat/completions", openai.ChatMiddleware(), s.ChatHandler)
-	r.POST("/v1/completions", openai.CompletionsMiddleware(), s.GenerateHandler)
-	r.POST("/v1/embeddings", openai.EmbeddingsMiddleware(), s.EmbedHandler)
-	r.GET("/v1/models", openai.ListMiddleware(), s.ListHandler)
-	r.GET("/v1/models/:model", openai.RetrieveMiddleware(), s.ShowHandler)
+	r.POST("/v1/chat/completions", openaimid.ChatMiddleware(), s.ChatHandler)
+	r.POST("/v1/completions", openaimid.CompletionsMiddleware(), s.GenerateHandler)
+	r.POST("/v1/embeddings", openaimid.EmbeddingsMiddleware(), s.EmbedHandler)
+	r.GET("/v1/models", openaimid.ListMiddleware(), s.ListHandler)
+	r.GET("/v1/models/:model", openaimid.RetrieveMiddleware(), s.ShowHandler)
 
 	if rc != nil {
 		// wrap old with new


### PR DESCRIPTION
## Summary
- break openai helpers into middleware/types/writer subpackages
- update server routes to use new middleware package

## Testing
- `go test ./...` *(fails: proxy access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b0d6a78688332bd507cae8b88d7b4