### PR TITLE
Add prompt slice support

### DIFF
--- a/docs/openai.md
+++ b/docs/openai.md
@@ -280,7 +280,7 @@ curl http://localhost:11434/v1/embeddings \
 
 #### Notes
 
-- `prompt` currently only accepts a string
+- `prompt` may be provided as a string, a slice of strings, a slice of token IDs (`[]int`), or a nested slice of token IDs (`[][]int`)
 
 ### `/v1/models`
 

--- a/openai/types/types.go
+++ b/openai/types/types.go
@@ -112,7 +112,7 @@ type ChatCompletionChunk struct {
 	Usage             *Usage        `json:"usage,omitempty"`
 }
 
-// TODO (https://github.com/goobla/goobla/issues/5259): support []string, []int and [][]int
+// Supports using string, []string, []int, or [][]int for the Prompt field.
 
 type CompletionRequest struct {
 	Model            string         `json:"model"`
@@ -537,6 +537,20 @@ func FromCompleteRequest(r CompletionRequest) (api.GenerateRequest, error) {
 	switch p := r.Prompt.(type) {
 	case string:
 		prompt = p
+	case []string:
+		if len(p) > 0 {
+			var sb strings.Builder
+			for _, s := range p {
+				sb.WriteString(s)
+			}
+			prompt = sb.String()
+		}
+	case []int:
+		context = append(context, p...)
+	case [][]int:
+		if len(p) > 0 {
+			context = append(context, p[0]...)
+		}
 	case []any:
 		if len(p) == 0 {
 			prompt = ""

--- a/openai/types/types_test.go
+++ b/openai/types/types_test.go
@@ -1,0 +1,78 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/goobla/goobla/api"
+)
+
+var False = false
+
+func TestFromCompleteRequestPromptTypes(t *testing.T) {
+	testCases := []struct {
+		name   string
+		req    CompletionRequest
+		expect api.GenerateRequest
+	}{
+		{
+			name: "string slice",
+			req:  CompletionRequest{Model: "test-model", Prompt: []string{"Hello", "World"}},
+			expect: api.GenerateRequest{
+				Model:  "test-model",
+				Prompt: "HelloWorld",
+				Options: map[string]any{
+					"frequency_penalty": float32(0),
+					"presence_penalty":  float32(0),
+					"temperature":       1.0,
+					"top_p":             1.0,
+				},
+				Stream: &False,
+			},
+		},
+		{
+			name: "token slice",
+			req:  CompletionRequest{Model: "test-model", Prompt: []int{1, 2, 3}},
+			expect: api.GenerateRequest{
+				Model:   "test-model",
+				Context: []int{1, 2, 3},
+				Options: map[string]any{
+					"frequency_penalty": float32(0),
+					"presence_penalty":  float32(0),
+					"temperature":       1.0,
+					"top_p":             1.0,
+				},
+				Stream: &False,
+			},
+		},
+		{
+			name: "nested token slice",
+			req:  CompletionRequest{Model: "test-model", Prompt: [][]int{{1, 2, 3}}},
+			expect: api.GenerateRequest{
+				Model:   "test-model",
+				Context: []int{1, 2, 3},
+				Options: map[string]any{
+					"frequency_penalty": float32(0),
+					"presence_penalty":  float32(0),
+					"temperature":       1.0,
+					"top_p":             1.0,
+				},
+				Stream: &False,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := FromCompleteRequest(tc.req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expect, got); diff != "" {
+				t.Fatalf("requests did not match: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- allow `openai/types.FromCompleteRequest` to parse []string, []int, and [][]int
- test the new types
- document accepted prompt formats

## Testing
- `go test ./...` *(fails: proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b2022f3488332a0dc19b13007610a