### PR TITLE
Support single quotes in parser

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -563,7 +563,6 @@ func quote(s string) string {
 }
 
 func unquote(s string) (string, bool) {
-	// TODO: single quotes
 	if len(s) >= 3 && s[:3] == `"""` {
 		if len(s) >= 6 && s[len(s)-3:] == `"""` {
 			return s[3 : len(s)-3], true
@@ -574,6 +573,14 @@ func unquote(s string) (string, bool) {
 
 	if len(s) >= 1 && s[0] == '"' {
 		if len(s) >= 2 && s[len(s)-1] == '"' {
+			return s[1 : len(s)-1], true
+		}
+
+		return "", false
+	}
+
+	if len(s) >= 1 && s[0] == '\'' {
+		if len(s) >= 2 && s[len(s)-1] == '\'' {
 			return s[1 : len(s)-1], true
 		}
 

--- a/parser/unquote_test.go
+++ b/parser/unquote_test.go
@@ -1,0 +1,32 @@
+package parser
+
+import "testing"
+
+func TestUnquote(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{"triple", `"""hello"""`, "hello", true},
+		{"double", `"hello"`, "hello", true},
+		{"single", `'hello'`, "hello", true},
+		{"noquote", `hello`, "hello", true},
+		{"bad triple", `"""hello""`, "", false},
+		{"bad double", `"hello`, "", false},
+		{"bad single", `'hello`, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := unquote(tt.in)
+			if ok != tt.ok {
+				t.Fatalf("expected ok=%v got %v", tt.ok, ok)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %q got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- extend `unquote` to recognize single quoted strings
- add unit tests for `unquote` covering triple, double and single quotes

## Testing
- `go test ./...` *(fails: downloading modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b20257c2c83329c2d8196c76bba82