### PR TITLE
Handle 70B attn_v quantization

### DIFF
--- a/server/quantization_test.go
+++ b/server/quantization_test.go
@@ -66,6 +66,20 @@ func TestGetTensorNewType(t *testing.T) {
 			expected:    fsggml.TensorTypeQ5_K,
 		},
 		{
+			name: "attn_v.weight_70b_boost",
+			qs: quantizeState{
+				is70B:  true,
+				iAttnV: 0,
+				nAttnV: 2,
+			},
+			kv:          map[string]any{},
+			newType:     fsggml.TensorTypeQ4_K,
+			tensor_name: "blk.0.attn_v.weight",
+			shape:       []uint64{256},
+			ftype:       fsggml.FileTypeF32,
+			expected:    fsggml.TensorTypeQ5_K,
+		},
+		{
 			name: "attn_v.weight_8_expert",
 			qs:   quantizeState{},
 			kv: map[string]any{


### PR DESCRIPTION
## Summary
- support extra quantization bits for `attn_v.weight` in 70B models
- store a flag for 70B models and detect it during quantize
- add unit test covering this behaviour

## Testing
- `go test ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b2026df94833283cfd3e2c24cdf13