### PR TITLE
Document windows host:port limitation

### DIFF
--- a/docs/issues/windows-host-port.md
+++ b/docs/issues/windows-host-port.md
@@ -1,0 +1,5 @@
+# Windows limitation: host:port names
+
+Using model names that include a host and port (e.g. `localhost:5000/library/model:tag`) fails on Windows. The server stores models on disk using the name as a directory structure. Windows paths cannot contain `:` in directory names which makes these names invalid.
+
+Until this is addressed, avoid using a port in the host portion of model names on Windows.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,3 @@
+# Known Issues
+
+- [Windows: host:port names fail](issues/windows-host-port.md)

--- a/server/routes_list_test.go
+++ b/server/routes_list_test.go
@@ -22,7 +22,7 @@ func TestList(t *testing.T) {
 		"apple/OpenELM:latest",
 		"boreas:2b-code-v1.5-q6_K",
 		"notus:7b-v1-IQ2_S",
-		// TODO: host:port currently fails on windows (#4107)
+		// TODO: host:port currently fails on Windows (see docs/issues/windows-host-port.md)
 		// "localhost:5000/library/eurus:700b-v0.5-iq3_XXS",
 		"mynamespace/apeliotes:latest",
 		"myhost/mynamespace/lips:code",


### PR DESCRIPTION
## Summary
- document that host:port model names fail on Windows
- reference the issue from test TODO comment

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b202854748332a34f19ae4276cde9