### PR TITLE
Remove deprecated insecure parameter

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1323,9 +1323,8 @@ Download a model from the goobla library. Cancelled pulls are resumed from where
 
 ### Parameters
 
-- `model`: name of the model to pull
-- `insecure`: (optional) allow insecure connections to the library. Only use this if you are pulling from your own library during development.
-- `stream`: (optional) if `false` the response will be returned as a single response object, rather than a stream of objects
+ - `model`: name of the model to pull
+ - `stream`: (optional) if `false` the response will be returned as a single response object, rather than a stream of objects
 
 ### Examples
 
@@ -1395,9 +1394,8 @@ Upload a model to a model library. Requires registering for goobla.ai and adding
 
 ### Parameters
 
-- `model`: name of the model to push in the form of `<namespace>/<model>:<tag>`
-- `insecure`: (optional) allow insecure connections to the library. Only use this if you are pushing to your library during development.
-- `stream`: (optional) if `false` the response will be returned as a single response object, rather than a stream of objects
+ - `model`: name of the model to push in the form of `<namespace>/<model>:<tag>`
+ - `stream`: (optional) if `false` the response will be returned as a single response object, rather than a stream of objects
 
 ### Examples
 

--- a/server/internal/registry/server.go
+++ b/server/internal/registry/server.go
@@ -190,16 +190,6 @@ type params struct {
 	// Use [model()] to get the model name for both old and new API requests.
 	Model string `json:"model"`
 
-	// AllowNonTLS is a flag that indicates a client using HTTP
-	// is doing so, deliberately.
-	//
-	// Deprecated: This field is ignored and only present for this
-	// deprecation message. It should be removed in a future release.
-	//
-	// Users can simply use http to show intent to communicate insecurely,
-	// without awkward and confusing flags such as this.
-	AllowNonTLS bool `json:"insecure"`
-
 	// Stream, if true, will make the server send progress updates in a
 	// streaming of JSON objects. If false, the server will send a single
 	// JSON object with the final status as "success", or an error object


### PR DESCRIPTION
## Summary
- remove `AllowNonTLS` field from local registry handler
- drop `insecure` option from API documentation

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b261d62048332a902a8a4f8531f93