### PR TITLE
Remove Windows bypass requirement

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -52,9 +52,12 @@ If you want to build the installer, youll need to install
 - https://jrsoftware.org/isinfo.php
 
 
-In the top directory of this repo, run the following powershell script
-to build the goobla CLI, goobla app, and goobla installer.
+In the top directory of this repo, run the following PowerShell script
+to build the Goobla CLI, Goobla app, and Goobla installer.
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File .\scripts\build_windows.ps1
+./scripts/build_windows.ps1
 ```
+
+The script is code signed so it runs under the default execution policy; using
+`-ExecutionPolicy Bypass` is no longer required.

--- a/app/lifecycle/getstarted_windows.go
+++ b/app/lifecycle/getstarted_windows.go
@@ -14,8 +14,7 @@ func GetStarted() error {
 	var err error
 	bannerScript := filepath.Join(AppDir, "goobla_welcome.ps1")
 	args := []string{
-		// TODO once we're signed, the execution policy bypass should be removed
-		"powershell", "-noexit", "-ExecutionPolicy", "Bypass", "-nologo", "-file", bannerScript,
+		"powershell", "-noexit", "-nologo", "-file", bannerScript,
 	}
 	args[0], err = exec.LookPath(args[0])
 	if err != nil {

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -1,6 +1,6 @@
 #!powershell
 #
-# powershell -ExecutionPolicy Bypass -File .\scripts\build_windows.ps1
+# ./scripts/build_windows.ps1
 #
 # gcloud auth application-default login
 


### PR DESCRIPTION
## Summary
- remove the `-ExecutionPolicy Bypass` argument from the PowerShell
  launcher in the Windows lifecycle code
- update Windows build instructions for the signed build script
- note new script invocation in `build_windows.ps1`

## Testing
- `go test ./...` *(fails: unable to download modules – network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b261e27648332af54ea2cf4f1aa7a