### PR TITLE
Add pprof configuration

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -157,3 +157,10 @@ Goobla looks for acceleration libraries in the following paths relative to the `
 * `build/lib/goobla` (for development)
 
 If the libraries are not found, Goobla will not run with any acceleration libraries.
+
+## Profiling
+
+By default the server exposes Go's pprof handlers on the main port. Set the
+environment variable `GOOBLA_PPROF` to `off` to disable these endpoints or
+specify a host and port such as `127.0.0.1:6060` to run pprof on a separate
+port.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -186,6 +186,9 @@ var (
 	ContextLength = Uint("GOOBLA_CONTEXT_LENGTH", 4096)
 	// Auth enables authentication between the Goobla client and server
 	UseAuth = Bool("GOOBLA_AUTH")
+	// PprofAddr configures the pprof server address. Set to "off" to disable
+	// pprof or specify a custom address (e.g. 127.0.0.1:6060).
+	PprofAddr = String("GOOBLA_PPROF")
 )
 
 func String(s string) func() string {
@@ -274,6 +277,7 @@ func AsMap() map[string]EnvVar {
 		"GOOBLA_MULTIUSER_CACHE": {"GOOBLA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
 		"GOOBLA_CONTEXT_LENGTH":  {"GOOBLA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4096)"},
 		"GOOBLA_NEW_ENGINE":      {"GOOBLA_NEW_ENGINE", NewEngine(), "Enable the new Goobla engine"},
+		"GOOBLA_PPROF":           {"GOOBLA_PPROF", PprofAddr(), "Bind pprof to this address or 'off' to disable"},
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},

--- a/server/routes.go
+++ b/server/routes.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"net/netip"
 	"os"
 	"os/signal"
@@ -1280,7 +1281,27 @@ func Serve(ln net.Listener) error {
 		return err
 	}
 
-	http.Handle("/", h)
+	pprofAddr := strings.ToLower(envconfig.PprofAddr())
+	var srvr *http.Server
+	switch pprofAddr {
+	case "", "on":
+		// Use DefaultServeMux so we get net/http/pprof handlers on the
+		// main server.
+		http.Handle("/", h)
+		srvr = &http.Server{Handler: nil}
+	case "off", "false", "0":
+		srvr = &http.Server{Handler: h}
+	default:
+		// Serve application routes on the main server and start pprof on
+		// a separate port using the default mux.
+		srvr = &http.Server{Handler: h}
+		go func() {
+			slog.Info("pprof listening", "addr", pprofAddr)
+			if err := http.ListenAndServe(pprofAddr, nil); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				slog.Error("pprof server error", "error", err)
+			}
+		}()
+	}
 
 	ctx, done := context.WithCancel(context.Background())
 	schedCtx, schedDone := context.WithCancel(ctx)
@@ -1288,17 +1309,6 @@ func Serve(ln net.Listener) error {
 	s.sched = sched
 
 	slog.Info(fmt.Sprintf("Listening on %s (version %s)", ln.Addr(), version.Version))
-	srvr := &http.Server{
-		// Use http.DefaultServeMux so we get net/http/pprof for
-		// free.
-		//
-		// TODO(bmizerany): Decide if we want to make this
-		// configurable so it is not exposed by default, or allow
-		// users to bind it to a different port. This was a quick
-		// and easy way to get pprof, but it may not be the best
-		// way.
-		Handler: nil,
-	}
 
 	// listen for a ctrl+c and stop any loaded llm
 	signals := make(chan os.Signal, 1)


### PR DESCRIPTION
## Summary
- expose GOOBLA_PPROF to control the pprof server address
- conditionally start pprof server from routes.go
- document profiling option

## Testing
- `go test ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b26246a9083328de3e22971b3ba2d