### PR TITLE
Remove embed layer warning

### DIFF
--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -254,5 +254,6 @@ MESSAGE assistant yes
 
 - the **`Modelfile` is not case sensitive**. In the examples, uppercase instructions are used to make it easier to distinguish it from arguments.
 - Instructions can be in any order. In the examples, the `FROM` instruction is first to keep it easily readable.
+- Embedding layers in a `Modelfile` are no longer supported. Any existing embedding entries will be ignored during model creation.
 
 [1]: https://goobla.com/library

--- a/server/images.go
+++ b/server/images.go
@@ -313,9 +313,7 @@ func GetModel(name string) (*Model, error) {
 			model.ModelPath = filename
 			model.ParentModel = layer.From
 		case "application/vnd.goobla.image.embed":
-			// Deprecated in versions  > 0.1.2
-			// TODO: remove this warning in a future version
-			slog.Info("WARNING: model contains embeddings, but embeddings in modelfiles have been deprecated and will be ignored.")
+		// Deprecated in versions > 0.1.2. Embedding layers in Modelfiles are no longer supported and will be ignored.
 		case "application/vnd.goobla.image.adapter":
 			model.AdapterPaths = append(model.AdapterPaths, filename)
 		case "application/vnd.goobla.image.projector":


### PR DESCRIPTION
## Summary
- quietly ignore deprecated embedding layers in Modelfile images
- document that embeddings in Modelfiles are no longer supported

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b2627e2588332a20c7afcd38f07e0