### PR TITLE
Fix tool parser false positive

### DIFF
--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -432,24 +432,14 @@ func TestParser(t *testing.T) {
 			calls:   nil,
 		},
 
-		// TODO (jmorganca): this is a false positive, we should
-		// not be parsing this as a tool call
 		{
 			name: "json no args false positive",
 			inputs: []string{
 				`{say_hello!!!}`,
 			},
-			content: "",
+			content: `{say_hello!!!}`,
 			tmpl:    json,
-			calls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Index:     0,
-						Name:      "say_hello",
-						Arguments: api.ToolCallFunctionArguments{},
-					},
-				},
-			},
+			calls:   nil,
 		},
 		{
 			name: "list multiple",


### PR DESCRIPTION
## Summary
- prevent parser from treating `{say_hello!!!}` as a tool call by validating JSON before accepting a call
- add helper `findJSONObject` for extracting the first JSON object from the buffer
- extend unit tests with edge case

## Testing
- `go test ./...` *(fails: fetching modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b262994e883328f44153b03410df2